### PR TITLE
feat: send user full name instead of @username when message is banned

### DIFF
--- a/src/bot/listeners/on-text.listener.js
+++ b/src/bot/listeners/on-text.listener.js
@@ -66,7 +66,8 @@ class OnTextListener {
       if (rep.byRules?.rule) {
         try {
           const username = ctx.from?.username;
-          const writeUsername = username ? `@${username}` : '';
+          const fullName = ctx.from?.last_name ? `${ctx.from?.first_name} ${ctx.from?.last_name}` : ctx.from?.first_name;
+          const writeUsername = username ? `@${username}` : fullName;
 
           let debugMessage = '';
 

--- a/src/bot/listeners/on-text.listener.js
+++ b/src/bot/listeners/on-text.listener.js
@@ -67,7 +67,7 @@ class OnTextListener {
         try {
           const username = ctx.from?.username;
           const fullName = ctx.from?.last_name ? `${ctx.from?.first_name} ${ctx.from?.last_name}` : ctx.from?.first_name;
-          const writeUsername = username ? `@${username}` : fullName;
+          const writeUsername = username ? `@${username}` : fullName ?? '';
 
           let debugMessage = '';
 


### PR DESCRIPTION
https://trello.com/c/xWDw6l1s/20-send-user-display-name-instead-of-username