### PR TITLE
[Fix] [UABOT-240] Fix nsfwjs ESM compatibility and nodemon temp file watch 

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -5,7 +5,8 @@
     "./last-ctx.json",
     "./positives.json",
     "./negatives.json",
-    "node_modules"
+    "node_modules",
+    "./src/shared/video/temp/*"
   ],
   "exec": "tsx",
   "ext": "ts,mts,mjs,js,json,ftl",

--- a/patches/nsfwjs+4.2.1.patch
+++ b/patches/nsfwjs+4.2.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/nsfwjs/dist/esm/index.js b/node_modules/nsfwjs/dist/esm/index.js
+index 5cd9e37..29c7094 100644
+--- a/node_modules/nsfwjs/dist/esm/index.js
++++ b/node_modules/nsfwjs/dist/esm/index.js
+@@ -44,7 +44,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+     return to.concat(ar || Array.prototype.slice.call(from));
+ };
+ import * as tf from "@tensorflow/tfjs";
+-import { Buffer } from "buffer/";
++import { Buffer } from "buffer";
+ import { NSFW_CLASSES } from "./nsfw_classes.js";
+ var availableModels = {
+     MobileNetV2: { numOfWeightBundles: 1 },


### PR DESCRIPTION
## What
Patches nsfwjs ESM import to resolve Node.js compatibility issue and excludes temp video files from nodemon's watch list.

## Why
The nsfwjs package uses a bare directory import (`buffer/`) which is not valid in Node.js ESM, causing a runtime error. Additionally, temp video files created during processing were triggering unnecessary nodemon restarts in development.

## Changes
- Added `patches/nsfwjs+4.2.1.patch` to fix nsfwjs ESM `buffer/` directory import → `buffer` (Node.js-compatible bare specifier)
- Updated `nodemon.json` to exclude `./src/shared/video/temp/*` from watch paths
